### PR TITLE
Fix memory leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Makefile to build zerofree and sparsify
+# Tuan T. Pham
+
+OBJS:=$(patsubst %.c,%.o,$(wildcard *.c))
+
+LIBS=-lext2fs
+
+all: sparsify zerofree
+
+%.o:%.c
+	@gcc -g -c -o $@ $<
+
+sparsify: sparsify.o
+	@gcc -c -o sparsify.o sparsify.c
+
+zerofree: zerofree.o
+	@gcc -g -o zerofree zerofree.o $(LIBS)
+
+clean:
+	@rm -f $(OBJS) sparsify zerofree


### PR DESCRIPTION
zerofree: We should clean up the allocated memory when we finish or when we
encounter an error.

Signed-off-by: Tuan T. Pham tuan@vt.edu
